### PR TITLE
Close Designer when IWpfTextView is closed.

### DIFF
--- a/src/PerspexVS/PerspexEditorMargin.xaml.cs
+++ b/src/PerspexVS/PerspexEditorMargin.xaml.cs
@@ -41,6 +41,12 @@ namespace PerspexVS
             {
                 _designer.Xaml = textView.TextBuffer.CurrentSnapshot.GetText();
             };
+            textView.Closed += delegate
+            {
+                PerspexBuildEvents.Instance.BuildEnd -= Restart;
+                PerspexBuildEvents.Instance.ModeChanged -= OnModeChanged;
+                _designer.KillProcess();
+            };
             ReloadMetadata();
         }
 


### PR DESCRIPTION
Fixes an issue where the Designer process may not close when it should.
* Kills the designer process 
* Unsubscribes from build events so that the designer cannot be restarted erroneously.