### PR TITLE
Improved the xaml editor implementation of the PerspexDesigner.

### DIFF
--- a/src/PerspexVS/Helpers/Extensions.cs
+++ b/src/PerspexVS/Helpers/Extensions.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.TextManager.Interop;
+using PerspexVS.Internals;
 
 namespace PerspexVS.Helpers
 {
@@ -12,5 +15,9 @@ namespace PerspexVS.Helpers
             return shellSettingsManager.GetWritableSettingsStore(scope);
         }
 
+        internal static ITextBuffer GetTextBuffer(this IVsTextLines vsTextBuffer)
+        {
+            return VisualStudioServices.VsEditorAdaptersFactoryService.GetDataBuffer(vsTextBuffer);
+        }
     }
 }

--- a/src/PerspexVS/Infrastructure/PerspexDesignerPane.IOleCommandTarget.cs
+++ b/src/PerspexVS/Infrastructure/PerspexDesignerPane.IOleCommandTarget.cs
@@ -6,6 +6,9 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using PerspexVS.Internals;
 using Constants = Microsoft.VisualStudio.OLE.Interop.Constants;
 
 namespace PerspexVS.Infrastructure
@@ -18,7 +21,7 @@ namespace PerspexVS.Infrastructure
         {
             get
             {
-                return _editorCommandTarget ?? (_editorCommandTarget = (IOleCommandTarget)_textView);
+                return _editorCommandTarget ?? (_editorCommandTarget = (IOleCommandTarget)_vsCodeWindow);
             }
         }
 
@@ -154,8 +157,14 @@ namespace PerspexVS.Infrastructure
             _designerHost.Container.SwapActiveView();
             if (_designerHost.Container.IsEditorActive)
             {
-                var editorControl = _wpfTextViewHost.TextView.VisualElement as IInputElement;
-                editorControl?.Focus();
+                IVsTextView lastActiveView;
+                GetLastActiveView(out lastActiveView);
+
+                var wpfEditorView = lastActiveView as IWpfTextView;
+                if (wpfEditorView != null)
+                {
+                    wpfEditorView.VisualElement.Focus();
+                }
             }
         }
 

--- a/src/PerspexVS/Infrastructure/PerspexDesignerPane.IVsFindTarget.cs
+++ b/src/PerspexVS/Infrastructure/PerspexDesignerPane.IVsFindTarget.cs
@@ -1,73 +1,371 @@
-﻿using Microsoft.VisualStudio.OLE.Interop;
+﻿using System;
+using EnvDTE;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace PerspexVS.Infrastructure
 {
-    public partial class PerspexDesignerPane : IVsFindTarget, IVsFindTarget2
+    public partial class PerspexDesignerPane : IVsFindTarget,
+        IVsFindTarget2,
+        IVsDropdownBarManager,
+        IVsUserData,
+        IVsHasRelatedSaveItems,
+        IVsToolboxUser,
+        IVsStatusbarUser,
+        IVsCodeWindow,
+        IVsCodeWindowEx,
+        IVsCodeWindow2,
+        IConnectionPointContainer,
+        IVsWindowFrameNotify2,
+        IExtensibleObject,
+        IObjectWithSite,
+        Microsoft.VisualStudio.OLE.Interop.IServiceProvider,
+        IVsBackForwardNavigation,
+        IVsBackForwardNavigation2,
+        IVsDocOutlineProvider,
+        IVsTextEditorPropertyContainer
     {
         public int GetCapabilities(bool[] pfImage, uint[] pgrfOptions)
         {
-            return VsFindTarget.GetCapabilities(pfImage, pgrfOptions);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetCapabilities(pfImage, pgrfOptions);
         }
 
         public int GetProperty(uint propid, out object pvar)
         {
-            return VsFindTarget.GetProperty(propid, out pvar);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetProperty(propid, out pvar);
         }
 
         public int GetSearchImage(uint grfOptions, IVsTextSpanSet[] ppSpans, out IVsTextImage ppTextImage)
         {
-            return VsFindTarget.GetSearchImage(grfOptions, ppSpans, out ppTextImage);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetSearchImage(grfOptions, ppSpans, out ppTextImage);
         }
 
         public int Find(string pszSearch, uint grfOptions, int fResetStartPoint, IVsFindHelper pHelper, out uint pResult)
         {
-            return VsFindTarget.Find(pszSearch, grfOptions, fResetStartPoint, pHelper, out pResult);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.Find(pszSearch, grfOptions, fResetStartPoint, pHelper, out pResult);
         }
 
         public int Replace(string pszSearch, string pszReplace, uint grfOptions, int fResetStartPoint, IVsFindHelper pHelper, out int pfReplaced)
         {
-            return VsFindTarget.Replace(pszSearch, pszReplace, grfOptions, fResetStartPoint, pHelper, out pfReplaced);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.Replace(pszSearch, pszReplace, grfOptions, fResetStartPoint, pHelper, out pfReplaced);
         }
 
         public int GetMatchRect(RECT[] prc)
         {
-            return VsFindTarget.GetMatchRect(prc);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetMatchRect(prc);
         }
 
         public int NavigateTo(TextSpan[] pts)
         {
-            return VsFindTarget.NavigateTo(pts);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.NavigateTo(pts);
         }
 
         public int GetCurrentSpan(TextSpan[] pts)
         {
-            return VsFindTarget.GetCurrentSpan(pts);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetCurrentSpan(pts);
         }
 
         public int SetFindState(object pUnk)
         {
-            return VsFindTarget.SetFindState(pUnk);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.SetFindState(pUnk);
         }
 
         public int GetFindState(out object ppunk)
         {
-            return VsFindTarget.GetFindState(out ppunk);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.GetFindState(out ppunk);
         }
 
         public int NotifyFindTarget(uint notification)
         {
-            return VsFindTarget.NotifyFindTarget(notification);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.NotifyFindTarget(notification);
         }
 
         public int MarkSpan(TextSpan[] pts)
         {
-            return VsFindTarget.MarkSpan(pts);
+            var findTarget = (IVsFindTarget)_vsCodeWindow;
+            return findTarget.MarkSpan(pts);
         }
 
         public int NavigateTo2(IVsTextSpanSet pSpans, TextSelMode iSelMode)
         {
-            return ((IVsFindTarget2)VsFindTarget).NavigateTo2(pSpans, iSelMode);
+            var findTarget = (IVsFindTarget2)_vsCodeWindow;
+            return findTarget.NavigateTo2(pSpans, iSelMode);
+        }
+
+        public IVsDropdownBarManager DropdownBarManager
+        {
+            get { return (IVsDropdownBarManager) _vsCodeWindow; }
+        }
+
+        public int AddDropdownBar(int cCombos, IVsDropdownBarClient pClient)
+        {
+            return DropdownBarManager.AddDropdownBar(cCombos, pClient);
+        }
+
+        public int GetDropdownBar(out IVsDropdownBar ppDropdownBar)
+        {
+            return DropdownBarManager.GetDropdownBar(out ppDropdownBar);
+        }
+
+        public int RemoveDropdownBar()
+        {
+            return DropdownBarManager.RemoveDropdownBar();
+        }
+
+        public IVsUserData VsUserData
+        {
+            get { return (IVsUserData) _vsCodeWindow; }
+        }
+
+        public int GetData(ref Guid riidKey, out object pvtData)
+        {
+            return VsUserData.GetData(ref riidKey, out pvtData);
+        }
+
+        public int SetData(ref Guid riidKey, object vtData)
+        {
+            return VsUserData.GetData(ref riidKey, out vtData);
+        }
+
+        public int GetRelatedSaveTreeItems(VSSAVETREEITEM saveItem, uint celt, VSSAVETREEITEM[] rgSaveTreeItems, out uint pcActual)
+        {
+            var codeWindow = (IVsHasRelatedSaveItems) _vsCodeWindow;
+            return codeWindow.GetRelatedSaveTreeItems(saveItem, celt, rgSaveTreeItems, out pcActual);
+        }
+
+        public int IsSupported(IDataObject pDO)
+        {
+            var toolboxUser = (IVsToolboxUser) _vsCodeWindow;
+            return toolboxUser.IsSupported(pDO);
+        }
+
+        public int ItemPicked(IDataObject pDO)
+        {
+            var toolboxUser = (IVsToolboxUser)_vsCodeWindow;
+            return toolboxUser.IsSupported(pDO);
+        }
+
+        public int SetInfo()
+        {
+            var codeWindow = (IVsStatusbarUser) _vsCodeWindow;
+            return codeWindow.SetInfo();
+        }
+
+        public int SetBuffer(IVsTextLines pBuffer)
+        {
+            return _vsCodeWindow.SetBuffer(pBuffer);
+        }
+
+        public int GetBuffer(out IVsTextLines ppBuffer)
+        {
+            return _vsCodeWindow.GetBuffer(out ppBuffer);
+        }
+
+        public int GetPrimaryView(out IVsTextView ppView)
+        {
+            return _vsCodeWindow.GetPrimaryView(out ppView);
+        }
+
+        public int GetSecondaryView(out IVsTextView ppView)
+        {
+            return _vsCodeWindow.GetSecondaryView(out ppView);
+        }
+
+        public int SetViewClassID(ref Guid clsidView)
+        {
+            return _vsCodeWindow.SetViewClassID(ref clsidView);
+        }
+
+        public int GetViewClassID(out Guid pclsidView)
+        {
+            return _vsCodeWindow.GetViewClassID(out pclsidView);
+        }
+
+        public int SetBaseEditorCaption(string[] pszBaseEditorCaption)
+        {
+            return _vsCodeWindow.SetBaseEditorCaption(pszBaseEditorCaption);
+        }
+
+        public int GetEditorCaption(READONLYSTATUS dwReadOnly, out string pbstrEditorCaption)
+        {
+            return _vsCodeWindow.GetEditorCaption(dwReadOnly, out pbstrEditorCaption);
+        }
+
+        public int Close()
+        {
+            return _vsCodeWindow.Close();
+        }
+
+        public int GetLastActiveView(out IVsTextView ppView)
+        {
+            return _vsCodeWindow.GetLastActiveView(out ppView);
+        }
+
+        public int Initialize(uint grfCodeWindowBehaviorFlags,
+                              VSUSERCONTEXTATTRIBUTEUSAGE usageAuxUserContext,
+                              string szNameAuxUserContext,
+                              string szValueAuxUserContext,
+                              uint initViewFlags,
+                              INITVIEW[] pInitView)
+        {
+            var vsCodeWindow = (IVsCodeWindowEx) _vsCodeWindow;
+            return vsCodeWindow.Initialize(grfCodeWindowBehaviorFlags, usageAuxUserContext, szNameAuxUserContext, szValueAuxUserContext, initViewFlags, pInitView);
+        }
+
+        public int IsReadOnly()
+        {
+            var vsCodeWindow = (IVsCodeWindowEx) _vsCodeWindow;
+            return vsCodeWindow.IsReadOnly();
+        }
+
+        public int GetProperty(VSEDITPROPID idProp, out object pvar)
+        {
+            var codeWindow = (IVsTextEditorPropertyContainer) _vsCodeWindow;
+            return codeWindow.GetProperty(idProp, out pvar);
+        }
+
+        public int SetProperty(VSEDITPROPID idProp, object var)
+        {
+            var codeWindow = (IVsTextEditorPropertyContainer)_vsCodeWindow;
+            return codeWindow.SetProperty(idProp, var);
+        }
+
+        public int RemoveProperty(VSEDITPROPID idProp)
+        {
+            var codeWindow = (IVsTextEditorPropertyContainer)_vsCodeWindow;
+            return codeWindow.RemoveProperty(idProp);
+        }
+
+        public void EnumConnectionPoints(out IEnumConnectionPoints ppEnum)
+        {
+            var codeWindow = (IConnectionPointContainer) _vsCodeWindow;
+            codeWindow.EnumConnectionPoints(out ppEnum);
+        }
+
+        public void FindConnectionPoint(ref Guid riid, out IConnectionPoint ppCP)
+        {
+            var codeWindow = (IConnectionPointContainer) _vsCodeWindow;
+            codeWindow.FindConnectionPoint(ref riid, out ppCP);
+        }
+
+        private IVsTextManager _textManager;
+        internal IVsTextManager TextManager
+        {
+            get
+            {
+                if (this._textManager == null)
+                    this._textManager = (IVsTextManager)this.GetService(typeof(SVsTextManager));
+                return this._textManager;
+            }
+        }
+
+        public int OnClose(ref uint pgrfSaveOptions)
+        {
+            // currently if we route the call to the _vsCodeWindow instance
+            // we will get an 'System.NullReferenceException' in Microsoft.VisualStudio.Editor.Implementation.dll
+            // for now we skip the call and return an OK
+
+            return VSConstants.S_OK;
+
+            //var codeWindow = (IVsWindowFrameNotify2)_vsCodeWindow;
+            //return codeWindow.OnClose(ref pgrfSaveOptions);
+        }
+
+        public void GetAutomationObject(string Name, IExtensibleObjectSite pParent, out object ppDisp)
+        {
+            var extensibleObject = (IExtensibleObject) _vsCodeWindow;
+            extensibleObject.GetAutomationObject(Name, pParent, out ppDisp);
+        }
+
+        public void SetSite(object pUnkSite)
+        {
+            var objectWithSite = (IObjectWithSite) _vsCodeWindow;
+            objectWithSite.SetSite(pUnkSite);
+        }
+
+        public void GetSite(ref Guid riid, out IntPtr ppvSite)
+        {
+            var objectWithSite = (IObjectWithSite)_vsCodeWindow;
+            objectWithSite.GetSite(ref riid, out ppvSite);
+        }
+
+        public int QueryService(ref Guid guidService, ref Guid riid, out IntPtr ppvObject)
+        {
+            var codeWindow = (Microsoft.VisualStudio.OLE.Interop.IServiceProvider) _vsCodeWindow;
+            return codeWindow.QueryService(ref guidService, ref riid, out ppvObject);
+        }
+
+        public int NavigateTo(IVsWindowFrame pFrame, string bstrData, object punk)
+        {
+            var codeWindow = (IVsBackForwardNavigation) _vsCodeWindow;
+            return codeWindow.NavigateTo(pFrame, bstrData, punk);
+        }
+
+        public int IsEqual(IVsWindowFrame pFrame, string bstrData, object punk, out int fReplaceSelf)
+        {
+            var codeWindow = (IVsBackForwardNavigation) _vsCodeWindow;
+            return codeWindow.IsEqual(pFrame, bstrData, punk, out fReplaceSelf);
+        }
+
+        public bool RequestAddNavigationItem(IVsWindowFrame frame)
+        {
+            var codeWindow = (IVsBackForwardNavigation2)_vsCodeWindow;
+            return codeWindow.RequestAddNavigationItem(frame);
+        }
+
+        public int GetOutlineCaption(VSOUTLINECAPTION nCaptionType, out string pbstrCaption)
+        {
+            var outlineProvider = (IVsDocOutlineProvider) _vsCodeWindow;
+            return outlineProvider.GetOutlineCaption(nCaptionType, out pbstrCaption);
+        }
+
+        public int GetOutline(out IntPtr phwnd, out IOleCommandTarget ppCmdTarget)
+        {
+            var outlineProvider = (IVsDocOutlineProvider)_vsCodeWindow;
+            return outlineProvider.GetOutline(out phwnd, out ppCmdTarget);
+        }
+
+        public int ReleaseOutline(IntPtr hwnd, IOleCommandTarget pCmdTarget)
+        {
+            var outlineProvider = (IVsDocOutlineProvider)_vsCodeWindow;
+            return outlineProvider.ReleaseOutline(hwnd, pCmdTarget);
+        }
+
+        public int OnOutlineStateChange(uint dwMask, uint dwState)
+        {
+            var outlineProvider = (IVsDocOutlineProvider)_vsCodeWindow;
+            return outlineProvider.OnOutlineStateChange(dwMask, dwState);
+        }
+
+        public int GetEmbeddedCodeWindowCount(out int piCount)
+        {
+            var vsCodeWindow = (IVsCodeWindow2) _vsCodeWindow;
+            return vsCodeWindow.GetEmbeddedCodeWindowCount(out piCount);
+        }
+
+        public int GetEmbeddedCodeWindow(int iIndex, out IVsCodeWindow ppCodeWindow)
+        {
+            var vsCodeWindow = (IVsCodeWindow2)_vsCodeWindow;
+            return vsCodeWindow.GetEmbeddedCodeWindow(iIndex, out ppCodeWindow);
+        }
+
+        public int GetContainingCodeWindow(out IVsCodeWindow ppCodeWindow)
+        {
+            var vsCodeWindow = (IVsCodeWindow2)_vsCodeWindow;
+            return vsCodeWindow.GetContainingCodeWindow(out ppCodeWindow);
         }
     }
 }

--- a/src/PerspexVS/Internals/VsComInterfaces.cs
+++ b/src/PerspexVS/Internals/VsComInterfaces.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace PerspexVS.Internals
+{
+    // TODO: those are some of the interface that should be implemented by the PerspexDesignerPane, to be fully compatible with the 
+    // internal implementation of VsCodeWindowAdapter
+
+    [Guid("47AB8522-6BB1-4C85-BA88-E4B4513F8BE1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComImport]
+    public interface IVsFindTarget4
+    {
+        int get_IsAutonomous();
+        int get_IsIncrementalSearchSupported();
+    }
+
+    [Guid("A2F0D62B-D0DD-4C59-AAB8-79CD20785451")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComImport]
+    public interface IVsFindTarget3
+    {
+        int get_IsNewUISupported();
+        int NotifyShowingNewUI();
+    }
+
+    [Guid("F657BA30-A2E2-4381-9AC8-F51C73962284")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComImport]
+    public interface IVsEmbeddedCodeWindowHost
+    {
+        void OnNewEmbeddedCodeWindow(IVsCodeWindow codeWindow, bool isReadOnly);
+        void OnCloseEmbeddedCodeWindow(IVsCodeWindow codeWindow);
+    }
+}

--- a/src/PerspexVS/PerspexVS.csproj
+++ b/src/PerspexVS/PerspexVS.csproj
@@ -73,6 +73,7 @@
     <Compile Include="IntelliSense\CompletionCommandHandler.cs" />
     <Compile Include="IntelliSense\CompletionSource.cs" />
     <Compile Include="IntelliSense\MetadataLoader.cs" />
+    <Compile Include="Internals\VsComInterfaces.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
     <Compile Include="Infrastructure\DocumentView.cs" />
     <Compile Include="ViewModels\IPerspexDesignerGeneralPageViewModel.cs" />
@@ -97,7 +98,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Infrastructure\Key.snk" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="packages\Rx-Core.2.2.5.nupkg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -215,6 +218,16 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.Wpf.14.1.24720\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.11.0.11.0.61030\lib\Microsoft.VisualStudio.TextManager.Interop.11.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.12.0.12.0.30110\lib\Microsoft.VisualStudio.TextManager.Interop.12.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/PerspexVS/packages.config
+++ b/src/PerspexVS/packages.config
@@ -19,6 +19,8 @@
   <package id="Microsoft.VisualStudio.Text.UI" version="14.1.24720" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="14.1.24720" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.11.0" version="11.0.61030" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.12.0" version="12.0.30110" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Threading" version="14.1.114" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.1.24720" targetFramework="net452" />


### PR DESCRIPTION
Previously the **WPF Editor** is extracted from the **IVsCodeWindow** instance that we create, the limitation of this approach was that we had to provide our own implementation for the various interfaces to have a good integration with Visual Studio. Some of which requires access to internal API, or I am not aware of how to achieve them at the moment. One of those is the ability to split the editor, and have two views of the same document.

So the solution was to wrap the **IVsCodeWindow** in our custom pane, and route all interface implementations to this instance, only one call failed which is the **OnSave(ref ...)**. the exception is raised in one of the internal classes, so I skipped its call by returning the success code.

Some interfaces are not yet implemented, those resides in **VsComInterfaces** class.
